### PR TITLE
golang-devopspro to 0.0.1

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -10,3 +10,6 @@ dependencies:
   name: exposecontroller
   repository: http://chartmuseum.build.cd.jenkins-x.io
   version: 2.3.58
+- name: golang-devopspro
+  repository: http://jenkins-x-chartmuseum:8080
+  version: 0.0.1


### PR DESCRIPTION
Promote golang-devopspro to version 0.0.1